### PR TITLE
Update Google model to gemini-2.5-pro-preview-06-05

### DIFF
--- a/src/phone_a_friend_mcp_server/config.py
+++ b/src/phone_a_friend_mcp_server/config.py
@@ -37,7 +37,7 @@ class PhoneAFriendConfig:
 
     def _get_default_model(self) -> str:
         """Get default model based on provider."""
-        models = {"openai": "o3", "openrouter": "anthropic/claude-4-opus", "anthropic": "claude-4-opus", "google": "gemini-2.5-pro-preview-05-06"}
+        models = {"openai": "o3", "openrouter": "anthropic/claude-4-opus", "anthropic": "claude-4-opus", "google": "gemini-2.5-pro-preview-06-05"}
         if self.provider not in models:
             raise ValueError(f"Unknown provider: {self.provider}. Supported providers: {list(models.keys())}")
         return models[self.provider]


### PR DESCRIPTION
## 🔄 Model Update

Updated Google's Gemini model from `gemini-2.5-pro-preview-05-06` to `gemini-2.5-pro-preview-06-05`.

### Changes
- Updated default model configuration in `config.py`
- Changed Google provider model from old preview version to newer preview version

### Testing
- [x] Configuration change verified
- [x] No breaking changes to existing functionality

### Notes
This is a straightforward model version update that maintains compatibility while using the latest available Gemini preview model.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author